### PR TITLE
Implements optimization for adjacent resistors

### DIFF
--- a/src/main/kotlin/org/eln2/mc/Extensions.kt
+++ b/src/main/kotlin/org/eln2/mc/Extensions.kt
@@ -46,10 +46,7 @@ import net.minecraft.world.phys.shapes.VoxelShape
 import net.minecraftforge.common.ForgeMod
 import net.minecraftforge.items.ItemStackHandler
 import net.minecraftforge.network.NetworkHooks
-import org.ageseries.libage.data.BiMap
-import org.ageseries.libage.data.MutableSetMapMultiMap
-import org.ageseries.libage.data.Quantity
-import org.ageseries.libage.data.mutableBiMapOf
+import org.ageseries.libage.data.*
 import org.ageseries.libage.sim.Material
 import org.ageseries.libage.sim.Scale
 import org.ageseries.libage.sim.electrical.mna.Circuit
@@ -388,9 +385,6 @@ inline fun <reified T : Cell> Level.getCell(mb: MultiblockManager, cellPosId: Bl
 */
 
 const val LIBAGE_SET_EPS = 1e-3
-fun org.ageseries.libage.sim.electrical.mna.component.Component.connect(pin: Int, info: ElectricalComponentInfo) {
-    this.connect(pin, info.component, info.index)
-}
 
 fun Circuit.add(holder: ComponentHolder<*>) {
     this.add(holder.instance)
@@ -1151,3 +1145,5 @@ fun VoxelShape.toBoxList() : List<AABB> {
 
     return results
 }
+
+fun<K, V> MultiMap<K, V>.valueSequence() = this.valueSets.asSequence().flatten()

--- a/src/main/kotlin/org/eln2/mc/Extensions.kt
+++ b/src/main/kotlin/org/eln2/mc/Extensions.kt
@@ -1106,6 +1106,12 @@ fun<K, V> MutableMap<K, V>.putUnique(key: K, value: V) {
     }
 }
 
+fun<V> MutableSet<V>.addUnique(value: V) {
+    require(this.add(value)) {
+        "Element $value was not unique"
+    }
+}
+
 /**
  * Gets the celestial phase from the in-game celestial angle.
  * @param sunAngle The celestial angle, as per [Level.getSunAngle]
@@ -1147,3 +1153,9 @@ fun VoxelShape.toBoxList() : List<AABB> {
 }
 
 fun<K, V> MultiMap<K, V>.valueSequence() = this.valueSets.asSequence().flatten()
+
+fun<T> MutableSet<T>.removeFirst() : T {
+    val value = this.first()
+    this.remove(value)
+    return value
+}

--- a/src/main/kotlin/org/eln2/mc/Libage.kt
+++ b/src/main/kotlin/org/eln2/mc/Libage.kt
@@ -1,12 +1,16 @@
 package org.eln2.mc
 
 import mcp.mobius.waila.api.IPluginConfig
+import org.ageseries.libage.data.MutableSetMapMultiMap
 import org.ageseries.libage.data.biMapOf
 import org.ageseries.libage.sim.Material
 import org.ageseries.libage.sim.electrical.mna.Circuit
-import org.ageseries.libage.sim.electrical.mna.component.Component
+import org.ageseries.libage.sim.electrical.mna.component.*
 import org.ageseries.libage.sim.thermal.Temperature
 import org.ageseries.libage.sim.thermal.ThermalMass
+import org.eln2.mc.common.cells.foundation.ComponentHolder
+import org.eln2.mc.common.cells.foundation.NEGATIVE_PIN
+import org.eln2.mc.common.cells.foundation.POSITIVE_PIN
 import org.eln2.mc.data.HashDataTable
 import org.eln2.mc.integration.WailaNode
 import org.eln2.mc.integration.WailaTooltipBuilder
@@ -99,3 +103,489 @@ fun Circuit.addAll(components: Iterable<Component>) {
         this.add(it)
     }
 }
+
+interface ImaginaryComponent
+
+// marker interface for libage components to replace Any
+
+interface ElectricalComponentSet {
+    fun add(component: Component)
+    fun add(component: ImaginaryComponent)
+    fun <T> add(holder: ComponentHolder<T>) where T : Component
+    fun add(component: Any)
+}
+
+interface ElectricalConnectivityMap {
+    fun connect(a: ImaginaryComponent, aIdx: Int, b: ImaginaryComponent, bIdx: Int)
+    fun connect(a: Component, aIdx: Int, b: ImaginaryComponent, bIdx: Int)
+    fun connect(a: ImaginaryComponent, aIdx: Int, b: Component, bIdx: Int)
+    fun connect(a: Component, aIdx: Int, b: Component, bIdx: Int)
+    fun connect(a: Any, aIdx: Int, b: Any, bIdx: Int)
+}
+
+class CircuitBuilder(val circuit: Circuit): ElectricalComponentSet, ElectricalConnectivityMap {
+    private open class CircuitCallList {
+        open fun addComponent(component: Component) { }
+        open fun markConnection(a: Component, aIdx: Int, b: Component, bIdx: Int) { }
+    }
+
+    private class DebugCallList : CircuitCallList() {
+        data class Connection(val aIdx: Int, val b: Component, val bIdx: Int) {
+            override fun toString() = "$aIdx - $b $bIdx"
+        }
+
+        val components = HashSet<Component>()
+        val connections = MutableSetMapMultiMap<Component, Connection>()
+
+        override fun addComponent(component: Component) {
+            components.add(component)
+        }
+
+        override fun markConnection(a: Component, aIdx: Int, b: Component, bIdx: Int) {
+            connections[a].add(Connection(aIdx, b, bIdx))
+        }
+    }
+
+    val image = HashSet<Any>()
+
+    private var realized = false
+    private val lineResistors = HashSet<ResistorVirtual>()
+    private val lineToRealConnections = MutableSetMapMultiMap<ResistorVirtual, RealLineConnectionInfo>()
+    private val lineToLineConnections = MutableSetMapMultiMap<ResistorVirtual, LineLineConnectionInfo>()
+
+    // Null implementation
+    private val callList = CircuitCallList()
+
+    private fun checkRealized() = require(!realized) {
+        "Tried to continue building after realized"
+    }
+
+    private fun checkContains(component: Any) = require(image.contains(component)) {
+        "Tried to use component $component which was not added"
+    }
+
+    private fun checkPair(a: Any, b: Any) {
+        if(a === b) {
+            error("Cannot connect $a to itself")
+        }
+
+        checkContains(a)
+        checkContains(b)
+    }
+
+    override fun add(component: Component) {
+        checkRealized()
+
+        if(!image.add(component)) {
+            return
+        }
+
+        circuit.add(component)
+        callList.addComponent(component)
+    }
+
+    override fun add(component: ImaginaryComponent) {
+        checkRealized()
+
+        if(!image.add(component)) {
+            return
+        }
+
+        when (component) {
+            is ResistorVirtual -> {
+                lineResistors.add(component)
+            }
+
+            else -> {
+                error("Cannot add $component")
+            }
+        }
+    }
+
+    override fun add(component: Any) {
+        checkRealized()
+
+        when (component) {
+            is Component -> {
+                add(component)
+            }
+
+            is ComponentHolder<*> -> {
+                add(component.instance)
+            }
+
+            is ImaginaryComponent -> {
+                add(component)
+            }
+
+            else -> {
+                error("Cannot add $component")
+            }
+        }
+    }
+
+    override fun <T> add(holder: ComponentHolder<T>) where T : Component {
+        checkRealized()
+        add(holder.instance)
+    }
+
+    override fun connect(a: Component, aIdx: Int, b: Component, bIdx: Int) {
+        checkRealized()
+        checkPair(a, b)
+        require(circuit.components.contains(a) && circuit.components.contains(b)) {
+            "A, B not all in circuit"
+        }
+        a.connect(aIdx, b, bIdx)
+        callList.markConnection(a, aIdx, b, bIdx)
+    }
+
+    override fun connect(a: Component, aIdx: Int, b: ImaginaryComponent, bIdx: Int) {
+        checkRealized()
+        checkPair(a, b)
+
+        if(b is ResistorVirtual) {
+            if(bIdx != POSITIVE_PIN && bIdx != NEGATIVE_PIN) {
+                error("Invalid line pin $bIdx")
+            }
+
+            lineToRealConnections[b].add(RealLineConnectionInfo(a, aIdx, bIdx))
+
+            if(lineToLineConnections[b].any { it.localPin == bIdx }) {
+                error("Fused line and real connection on same pin is not allowed")
+            }
+        }
+        else {
+            error("Cannot connect $b")
+        }
+    }
+
+    override fun connect(a: ImaginaryComponent, aIdx: Int, b: Component, bIdx: Int) {
+        checkRealized()
+        connect(b, bIdx, a, aIdx)
+    }
+
+    override fun connect(a: ImaginaryComponent, aIdx: Int, b: ImaginaryComponent, bIdx: Int) {
+        checkRealized()
+        checkPair(a, b)
+
+        if(a is ResistorVirtual && b is ResistorVirtual) {
+            lineToLineConnections[a].add(LineLineConnectionInfo(b, bIdx, aIdx))
+            lineToLineConnections[b].add(LineLineConnectionInfo(a, aIdx, bIdx))
+        }
+        else {
+            error("Invalid components $a $b")
+        }
+    }
+
+    override fun connect(a: Any, aIdx: Int, b: Any, bIdx: Int) {
+        checkRealized()
+
+        if(a is Component && b is Component) {
+            connect(a, aIdx, b, bIdx)
+        }
+        else if(a is Component && b is ImaginaryComponent) {
+            connect(a, aIdx, b, bIdx)
+        }
+        else if(a is ComponentHolder<*> && b is ImaginaryComponent) {
+            connect(a.instance, aIdx, b, bIdx)
+        }
+        else if(a is ImaginaryComponent && b is Component) {
+            connect(a, aIdx, b, bIdx)
+        }
+        else if(a is ImaginaryComponent && b is ComponentHolder<*>) {
+            connect(a, aIdx, b.instance, bIdx)
+        }
+        else if(a is ImaginaryComponent && b is ImaginaryComponent) {
+            connect(a, aIdx, b, bIdx)
+        }
+        else {
+            error("Cannot connect $a and $b")
+        }
+    }
+
+    fun realizeVirtual() {
+        checkRealized()
+        compileLines()
+        realized = true
+    }
+
+    /**
+     * Gets the connections from [source], separated into 2 sets: one that concerns the positive pin of the virtual resistor, and one that concerns the negative pin of the virtual resistor.
+     * */
+    private fun getDisjointConnections(source: Iterable<LineLineConnectionInfo>) : Pair<List<LineLineConnectionInfo>, List<LineLineConnectionInfo>> {
+        val positive = ArrayList<LineLineConnectionInfo>(1)
+        val negative = ArrayList<LineLineConnectionInfo>(1)
+
+        source.forEach { connection ->
+            when (connection.localPin) {
+                POSITIVE_PIN -> {
+                    positive.add(connection)
+                }
+                NEGATIVE_PIN -> {
+                    negative.add(connection)
+                }
+                else -> {
+                    error("Invalid connection ${connection.localPin}")
+                }
+            }
+        }
+
+        return Pair(positive, negative)
+    }
+
+    /**
+     * Gets all line graphs.
+     * A line graph has:
+     * - One or two end points (outers) - these are virtual resistors that will "become the two ends" of the real Line resistor, because they have connections to other non-line resistors, and/or are the first/last resistors in a line (they have 0 or 1 connections)
+     * - Zero or multiple inner parts (inners) - these are virtual resistors that have 2 connections to other virtual resistors. These do not materialize into real Line resistors later on.
+     * */
+    private fun getLineGraphs() : List<LineGraph> {
+        val pending = HashSet(lineResistors)
+        val queue = ArrayDeque<ResistorVirtual>()
+        val results = ArrayList<LineGraph>()
+
+        while (pending.isNotEmpty()) {
+            val graph = LineGraph()
+
+            queue.add(pending.first())
+
+            while (queue.isNotEmpty()) {
+                val front = queue.removeFirst()
+
+                if(!graph.resistors.add(front)) {
+                    continue
+                }
+
+                pending.remove(front)
+
+                val realConnections = lineToRealConnections[front]
+                val lineConnections = lineToLineConnections[front]
+
+                val isInner = realConnections.isEmpty() && // If it has real connections, we need to do Line connections, therefore, it cannot be inner
+                    lineConnections.size == 2 && // If it has 0 or 1, it is either the single resistor in the graph or at one of the ends of the graph
+                    lineConnections.any { it.localPin == POSITIVE_PIN } && // The inner component will have 2 connections to other virtual resistors, one on the "positive" pin and one on the "negative" pin
+                    lineConnections.any { it.localPin == NEGATIVE_PIN }
+
+                if(isInner) {
+                    check(graph.inners.add(front))
+
+                    lineConnections.forEach { connection ->
+                        // We can go both left and right here, and we will encounter another inner or one of the end points
+                        queue.add(connection.remote)
+                    }
+                }
+                else {
+                    check(graph.outers.add(front))
+
+                    require(graph.outers.size <= 2) {
+                        "Got more than 2 end points"
+                    }
+
+                    /**
+                     * We are at an endpoint. Cases:
+                     * - This is the only resistor in the graph - the search stops here
+                     * - Both pins have real connections - this means [getDisjointConnections] will return empty-handed (we put a condition in our [connect] method that prevents a real and imaginary connection on the same pin of a virtual resistor)
+                     * - Only one of the pins may have a connection to another virtual resistor. We will explore towards that, to find the rest of the graph.
+                     * */
+                    val (positive, negative) = getDisjointConnections(lineConnections)
+
+                    require(!(positive.size == 1 && negative.size == 1)) {
+                        "Endpoint condition broken"
+                    }
+
+                    if(positive.size == 1) {
+                        queue.add(positive[0].remote)
+                    }
+
+                    if(negative.size == 1) {
+                        queue.add(negative[0].remote)
+                    }
+                }
+            }
+
+            results.add(graph)
+        }
+
+        return results
+    }
+
+    private fun compileLines() {
+        if(lineResistors.isEmpty()) {
+            return
+        }
+
+        // what to do with the pins?
+        // probably has something to do with the sign of the current
+
+        val graphs = getLineGraphs()
+
+        /**
+         * Maps an endpoint virtual resistor (R1) to its graph's connectivity map, at that endpoint.
+         * The connectivity map maps a remote virtual resistor (R2) that is connected via [lineToLineConnections] to R1 to the pin of the real Line component (owned by R1's line graph) assigned for the real connection between R1's line and R2's line.
+         * */
+        val imaginaryEdges = HashMap<ResistorVirtual, HashMap<ResistorVirtual, Pair<Line, Int>>>()
+        var pin = 0
+
+        graphs.forEach { graph ->
+            val line = graph.line
+
+            add(line)
+
+            graph.resistors.forEach { resistor ->
+                resistor.setHandle(line.add(line.size))
+            }
+
+            if(graph.resistors.size == 1) {
+                // Single resistor. The imaginary pins will be the same as the pins used by the real pins:
+                require(graph.outers.size == 1)
+                require(graph.inners.size == 0)
+                val outer = graph.outers.first()
+
+                lineToRealConnections[outer].forEach { (remote, remoteIdx, localIdx) ->
+                    connect(line, localIdx, remote, remoteIdx)
+                }
+
+                val connectivityMap = HashMap<ResistorVirtual, Pair<Line, Int>>(2)
+                imaginaryEdges.putUnique(outer, connectivityMap)
+
+                // There may be some imaginary resistors connected - they just didn't fit the line graph invariant, so they are not included in this graph
+                lineToLineConnections[outer].forEach { (remote, remoteIdx, localIdx) ->
+                    connectivityMap.putUnique(remote, Pair(line, localIdx))
+                }
+            }
+            else {
+                // A line of resistors. We will assign arbitrary pins to the (at most) 2 outers:
+                graph.outers.forEach { outer ->
+                    val connectivityMap = HashMap<ResistorVirtual, Pair<Line, Int>>(2)
+                    imaginaryEdges.putUnique(outer, connectivityMap)
+
+                    val arbitraryPin = (pin++) % 2
+
+                    // This time, the outer resistor's real connections will all receive the same arbitrary pin of the Line.
+                    lineToRealConnections[outer].forEach { (remote, remoteIdx, localIdx) ->
+                        connect(line, arbitraryPin, remote, remoteIdx)
+                    }
+
+                    // Other imaginary connections will use the arbitrary pin to connect to our Line:
+                    lineToLineConnections[outer].forEach { (remote, remoteIdx, localIdx) ->
+                        connectivityMap.putUnique(remote, Pair(line, arbitraryPin))
+                    }
+                }
+            }
+        }
+
+        // Resolve imaginary connections.
+        // These will materialize into connections between real Line components.
+        // These Line components are all generated here; they result from clusters of virtual resistors that need multiple Line resistors to be represented.
+        // We do have some residual lineToLineConnections. Those are from the connections between elements from the same lines (inner to inner and inner to end point).
+        // Only some of those will be between the end points (outers) of different lines, and those are the ones we need to tackle.
+        graphs.forEach { graph ->
+            graph.outers.forEach { outer ->
+                for (connection in lineToLineConnections[outer]) {
+                    if(graph.resistors.contains(connection.remote)) {
+                        // Residual connection to a component in the graph
+                        // Those will not materialize into real connections.
+                        continue
+                    }
+
+                    // This will contain the pin of the remote line that we need to connect to:
+                    val remoteEdgeMap = imaginaryEdges[connection.remote].requireNotNull {
+                        "Did not have remote edge map"
+                    }
+
+                    val (remoteLine, remotePin) = remoteEdgeMap[outer].requireNotNull {
+                        "Did not have remote imaginary edge"
+                    }
+
+                    // This will contain the pin of our line that we need to connect with the remote line.
+                    val localEdgeMap = imaginaryEdges[outer].requireNotNull {
+                        "Did not have local edge map"
+                    }
+
+                    val (localLine, localPin) = localEdgeMap[connection.remote].requireNotNull {
+                        "Did not have local imaginary edge"
+                    }
+
+                    check(graph.line == localLine)
+                    check(localLine != remoteLine)
+
+                    // Finally, this real connection will connect together the two Line components:
+                    connect(localLine, localPin, remoteLine, remotePin)
+                }
+            }
+        }
+    }
+
+    private data class RealLineConnectionInfo(
+        val remote: Component,
+        val remotePin: Int,
+        val localPin: Int
+    )
+
+    private data class LineLineConnectionInfo(
+        val remote: ResistorVirtual,
+        val remotePin: Int,
+        val localPin: Int
+    )
+
+    private class LineGraph {
+        val line = Line()
+
+        /**
+         * Gets all resistors in the cluster
+         * */
+        val resistors = HashSet<ResistorVirtual>()
+
+        /**
+         * Gets all inner resistors in the cluster
+         * */
+        val inners = HashSet<ResistorVirtual>()
+
+        /**
+         * Gets all end point resistors in the cluster
+         * */
+        val outers = HashSet<ResistorVirtual>()
+    }
+}
+
+interface ResistorLike : IPower {
+    var resistance: Double
+    val potential: Double
+    val current: Double
+}
+
+/**
+ * Resistor-like [ImaginaryComponent] that may or may not materialize into a real [Line] component.
+ * These resistors are grouped into lines, which brings enormous optimizations to circuits that have large sections of virtual resistors in series.
+ * */
+class ResistorVirtual : ResistorLike, ImaginaryComponent {
+    var part: Line.Part? = null
+        private set
+
+    fun setHandle(handle: Line.Part) {
+        this.part = handle
+        handle.resistance = this.resistance
+    }
+
+    override val power: Double
+        get() = part?.power ?: 0.0
+
+    override val potential: Double
+        get() = part?.potential ?: 0.0
+
+    override val current: Double
+        get() = part?.current ?: 0.0
+
+    override var resistance: Double = 1.0
+        set(value) {
+            if(field != value) {
+                field = value
+                part?.resistance = value
+            }
+        }
+
+    override fun toString() = "Virtual[L=${part?.line?.hashCode()}, P=${part?.hashCode()}, R=$resistance]"
+}
+
+// Libage when?
+class ResistorLikeResistor : Resistor(), ResistorLike

--- a/src/main/kotlin/org/eln2/mc/common/cells/foundation/Components.kt
+++ b/src/main/kotlin/org/eln2/mc/common/cells/foundation/Components.kt
@@ -145,7 +145,7 @@ class ResistorBundle(var resistance: Double, obj: ElectricalObject<*>) {
      * This "prepares" the bundle, so future calls to *getOfferedResistor* that result in a new resistor being created will cause an error.
      * @see ElectricalObject.addComponents
      * */
-    fun register(connections: List<ElectricalObject<*>>, circuit: Circuit) {
+    fun addComponents(connections: List<ElectricalObject<*>>, circuit: Circuit) {
         if (prepared) {
             error("Already prepared")
         }

--- a/src/main/kotlin/org/eln2/mc/common/cells/foundation/Components.kt
+++ b/src/main/kotlin/org/eln2/mc/common/cells/foundation/Components.kt
@@ -1,13 +1,8 @@
 package org.eln2.mc.common.cells.foundation
 
-import org.ageseries.libage.sim.electrical.mna.Circuit
 import org.ageseries.libage.sim.electrical.mna.component.Component
 import org.ageseries.libage.sim.electrical.mna.component.Resistor
-import org.eln2.mc.connect
-import org.eln2.mc.data.BlockLocator
-import org.eln2.mc.data.FaceLocator
-import org.eln2.mc.data.FacingLocator
-import org.eln2.mc.data.requireLocator
+import org.eln2.mc.*
 import kotlin.math.abs
 
 class ComponentHolder<T : Component>(private val factory: () -> T) {
@@ -23,72 +18,56 @@ class ComponentHolder<T : Component>(private val factory: () -> T) {
             return value!!
         }
 
-    fun connect(pin: Int, component: Component, remotePin: Int) {
-        instance.connect(pin, component, remotePin)
+    fun connect(pin: Int, component: Any, remotePin: Int, map: ElectricalConnectivityMap) {
+        map.connect(instance, pin, component, remotePin)
     }
 
-    fun connect(pin: Int, componentInfo: ElectricalComponentInfo) {
-        instance.connect(pin, componentInfo)
+    fun connect(pin: Int, componentInfo: ElectricalComponentInfo, map: ElectricalConnectivityMap) {
+        map.connect(instance, pin, componentInfo.component, componentInfo.index)
     }
 
-    fun connectInternal(component: Component, remotePin: Int) {
-        connect(INTERNAL_PIN, component, remotePin)
+    fun connectInternal(component: Any, remotePin: Int, map: ElectricalConnectivityMap) {
+        connect(INTERNAL_PIN, component, remotePin, map)
     }
 
-    fun connectInternal(componentInfo: ElectricalComponentInfo) {
-        connectInternal(componentInfo.component, componentInfo.index)
+    fun connectInternal(componentInfo: ElectricalComponentInfo, map: ElectricalConnectivityMap) {
+        connectInternal(componentInfo.component, componentInfo.index, map)
     }
 
-    fun connectExternal(component: Component, remotePin: Int) {
-        connect(EXTERNAL_PIN, component, remotePin)
+    fun connectExternal(component: Any, remotePin: Int, map: ElectricalConnectivityMap) {
+        connect(EXTERNAL_PIN, component, remotePin, map)
     }
 
-    fun connectExternal(componentInfo: ElectricalComponentInfo) {
-        connectExternal(componentInfo.component, componentInfo.index)
+    fun connectExternal(componentInfo: ElectricalComponentInfo, map: ElectricalConnectivityMap) {
+        connectExternal(componentInfo.component, componentInfo.index, map)
     }
 
-    fun connectExternal(owner: ElectricalObject<*>, connection: ElectricalObject<*>) {
-        connectExternal(connection.offerComponent(owner))
+    fun connectExternal(owner: ElectricalObject<*>, connection: ElectricalObject<*>, map: ElectricalConnectivityMap) {
+        connectExternal(connection.offerComponent(owner), map)
     }
 
-    fun connectPositive(component: Component, remotePin: Int) {
-        connect(POSITIVE_PIN, component, remotePin)
+    fun connectPositive(component: Any, remotePin: Int, map: ElectricalConnectivityMap) {
+        connect(POSITIVE_PIN, component, remotePin, map)
     }
 
-    fun connectPositive(componentInfo: ElectricalComponentInfo) {
-        connectPositive(componentInfo.component, componentInfo.index)
+    fun connectPositive(componentInfo: ElectricalComponentInfo, map: ElectricalConnectivityMap) {
+        connectPositive(componentInfo.component, componentInfo.index, map)
     }
 
-    fun connectPositive(owner: ElectricalObject<*>, connection: ElectricalObject<*>) {
-        connectPositive(connection.offerComponent(owner))
+    fun connectPositive(owner: ElectricalObject<*>, connection: ElectricalObject<*>, map: ElectricalConnectivityMap) {
+        connectPositive(connection.offerComponent(owner), map)
     }
 
-    fun connectNegative(component: Component, remotePin: Int) {
-        connect(NEGATIVE_PIN, component, remotePin)
+    fun connectNegative(component: Any, remotePin: Int, map: ElectricalConnectivityMap) {
+        connect(NEGATIVE_PIN, component, remotePin, map)
     }
 
-    fun connectNegative(componentInfo: ElectricalComponentInfo) {
-        connectNegative(componentInfo.component, componentInfo.index)
+    fun connectNegative(componentInfo: ElectricalComponentInfo, map: ElectricalConnectivityMap) {
+        connectNegative(componentInfo.component, componentInfo.index, map)
     }
 
-    fun connectNegative(owner: ElectricalObject<*>, connection: ElectricalObject<*>) {
-        connectNegative(connection.offerComponent(owner))
-    }
-
-    fun ground(pin: Int) {
-        instance.ground(pin)
-    }
-
-    fun groundInternal() {
-        ground(INTERNAL_PIN)
-    }
-
-    fun groundNegative() {
-        ground(NEGATIVE_PIN)
-    }
-
-    fun groundExternal() {
-        ground(EXTERNAL_PIN)
+    fun connectNegative(owner: ElectricalObject<*>, connection: ElectricalObject<*>, map: ElectricalConnectivityMap) {
+        connectNegative(connection.offerComponent(owner), map)
     }
 
     fun offerInternal(): ElectricalComponentInfo {
@@ -126,26 +105,54 @@ class ComponentHolder<T : Component>(private val factory: () -> T) {
     }
 }
 
+fun<T> ComponentHolder<T>.ground(pin: Int) where T : Component {
+    this.instance.ground(pin)
+}
+
+fun<T> ComponentHolder<T>.groundInternal() where T : Component {
+    this.ground(INTERNAL_PIN)
+}
+
+fun<T> ComponentHolder<T>.groundNegative() where T : Component  {
+    this.ground(NEGATIVE_PIN)
+}
+
+fun<T> ComponentHolder<T>.groundExternal() where T : Component  {
+    this.ground(EXTERNAL_PIN)
+}
+
 /**
  * Utility class that holds a collection of resistors to be used as contact points for external components.
  * */
-class ResistorBundle(var resistance: Double, obj: ElectricalObject<*>) {
-    init {
-        obj.cell.locator.requireLocator<BlockLocator>()
-        obj.cell.locator.requireLocator<FacingLocator>()
-        obj.cell.locator.requireLocator<FaceLocator>()
+open class ResistorLikeBundle<T : ResistorLike>(val factory: () -> T) {
+    constructor(resistance: Double, factory: () -> T) : this(factory) {
+        this.resistance = resistance
     }
 
-    private val resistors = HashMap<ElectricalObject<*>, Resistor>()
+    private val resistors = HashMap<ElectricalObject<*>, T>()
 
     private var prepared = false
+
+    var resistance: Double = 1.0
+        set(value) {
+            if(field != value) {
+                field = value
+                resistors.values.forEach {
+                    it.resistance = value
+                }
+            }
+        }
+
+    var crossResistance
+        get() = resistance * 2.0
+        set(value) { resistance = value / 2.0 }
 
     /**
      * This must be called once the circuit is made available, in order to register the resistors.
      * This "prepares" the bundle, so future calls to *getOfferedResistor* that result in a new resistor being created will cause an error.
      * @see ElectricalObject.addComponents
      * */
-    fun addComponents(connections: List<ElectricalObject<*>>, circuit: Circuit) {
+    fun addComponents(connections: List<ElectricalObject<*>>, circuit: ElectricalComponentSet) {
         if (prepared) {
             error("Already prepared")
         }
@@ -162,7 +169,7 @@ class ResistorBundle(var resistance: Double, obj: ElectricalObject<*>) {
      * This must be called after "prepare", to finalize connections.
      * @see ElectricalObject.build
      * */
-    fun connect(connections: List<ElectricalObject<*>>, sender: ElectricalObject<*>) {
+    fun connect(connections: List<ElectricalObject<*>>, sender: ElectricalObject<*>, map: ElectricalConnectivityMap) {
         if (!prepared) {
             error("Not prepared")
         }
@@ -170,21 +177,19 @@ class ResistorBundle(var resistance: Double, obj: ElectricalObject<*>) {
         connections.forEach { remoteObj ->
             val resistor = getResistor(remoteObj)
             val offered = remoteObj.offerComponent(sender)
-            resistor.connect(EXTERNAL_PIN, offered.component, offered.index)
+            map.connect(resistor, EXTERNAL_PIN, offered.component, offered.index)
         }
     }
 
-    private fun getResistor(remote: ElectricalObject<*>): Resistor {
+    private fun getResistor(remote: ElectricalObject<*>): T {
         return resistors.computeIfAbsent(remote) {
             if (prepared) {
                 error("Tried to create resistors after bundle was prepared")
             }
 
-            val result = Resistor()
-
+            val result = factory()
             result.resistance = resistance
-
-            return@computeIfAbsent result
+            result
         }
     }
 
@@ -201,7 +206,7 @@ class ResistorBundle(var resistance: Double, obj: ElectricalObject<*>) {
      * Iterates through all the initialized resistors.
      * Keep in mind that a resistor is initialized __after__ *getOfferedResistor* is called.
      * */
-    fun forEach(action: ((Resistor) -> Unit)) {
+    fun forEach(action: ((T) -> Unit)) {
         resistors.values.forEach { action(it) }
     }
 
@@ -217,3 +222,8 @@ class ResistorBundle(var resistance: Double, obj: ElectricalObject<*>) {
     val totalCurrent get() = resistors.values.sumOf { abs(it.current) }
     val totalPower get() = resistors.values.sumOf { abs(it.power) }
 }
+
+fun resistorBundle() = ResistorLikeBundle { ResistorLikeResistor() }
+fun resistorVirtualBundle() = ResistorLikeBundle { ResistorVirtual() }
+fun resistorBundle(resistance: Double) = ResistorLikeBundle(resistance) { ResistorLikeResistor() }
+fun resistorVirtualBundle(resistance: Double) = ResistorLikeBundle(resistance) { ResistorVirtual() }

--- a/src/main/kotlin/org/eln2/mc/common/cells/foundation/Components.kt
+++ b/src/main/kotlin/org/eln2/mc/common/cells/foundation/Components.kt
@@ -5,6 +5,7 @@ import org.ageseries.libage.sim.electrical.mna.component.Resistor
 import org.eln2.mc.*
 import kotlin.math.abs
 
+// TODO Please remove
 class ComponentHolder<T : Component>(private val factory: () -> T) {
     var value: T? = null
         private set

--- a/src/main/kotlin/org/eln2/mc/common/cells/foundation/Objects.kt
+++ b/src/main/kotlin/org/eln2/mc/common/cells/foundation/Objects.kt
@@ -147,6 +147,8 @@ abstract class ElectricalObject<C : Cell>(cell: C) : SimulationObject<C>(cell) {
 
     protected val connections = ArrayList<ElectricalObject<*>>()
 
+    val connectionList get() = connections as List<ElectricalObject<*>>
+
     final override val type = SimulationObjectType.Electrical
 
     /**

--- a/src/main/kotlin/org/eln2/mc/common/cells/foundation/Objects.kt
+++ b/src/main/kotlin/org/eln2/mc/common/cells/foundation/Objects.kt
@@ -2,7 +2,6 @@ package org.eln2.mc.common.cells.foundation
 
 import net.minecraft.nbt.CompoundTag
 import org.ageseries.libage.sim.electrical.mna.Circuit
-import org.ageseries.libage.sim.electrical.mna.component.Component
 import org.ageseries.libage.sim.thermal.ConnectionParameters
 import org.ageseries.libage.sim.thermal.Simulator
 import org.eln2.mc.*
@@ -29,11 +28,6 @@ abstract class SimulationObject<C : Cell>(val cell: C) {
      * Here, the previous state should be cleared so that the object is ready to join a new simulation.
      * */
     abstract fun clear()
-
-    /**
-     * Called when the solver is being built, after *clear*.
-     * */
-    abstract fun build()
 
     /**
      * Called when the cell is destroyed.
@@ -112,7 +106,7 @@ abstract class ThermalObject<C : Cell>(cell: C) : SimulationObject<C>(cell) {
         connections.clear()
     }
 
-    override fun build() {
+    fun build() {
         if (simulation == null) {
             error("Tried to build thermal obj with null simulation")
         }
@@ -134,7 +128,7 @@ abstract class ThermalObject<C : Cell>(cell: C) : SimulationObject<C>(cell) {
     protected abstract fun addComponents(simulator: Simulator)
 }
 
-data class ElectricalComponentInfo(val component: Component, val index: Int)
+data class ElectricalComponentInfo(val component: Any, val index: Int)
 
 abstract class ElectricalObject<C : Cell>(cell: C) : SimulationObject<C>(cell) {
     /**
@@ -177,10 +171,10 @@ abstract class ElectricalObject<C : Cell>(cell: C) : SimulationObject<C>(cell) {
      * Called by the building logic when the electrical object is made part of a circuit.
      * Also calls the *registerComponents* method.
      * */
-    fun setNewCircuit(circuit: Circuit) {
-        this.circuit = circuit
+    fun setNewCircuit(builder: CircuitBuilder) {
+        this.circuit = builder.circuit
 
-        addComponents(circuit)
+        addComponents(builder)
     }
 
     /**
@@ -214,23 +208,17 @@ abstract class ElectricalObject<C : Cell>(cell: C) : SimulationObject<C>(cell) {
      * Called when the solver is being built, and the components need to be re-created (or refreshed)
      * The connections are not available at this stage.
      * */
-    protected abstract fun clearComponents()
+    protected open fun clearComponents() { }
 
     /**
      * Called when the circuit must be updated with the components owned by this object.
      * This is called before build.
      * By default, offers for all [connections] are gathered using [offerComponent], and the offered components are all added to the [circuit]
      * */
-    protected open fun addComponents(circuit: Circuit) {
-        val components = HashSet<Component>(2)
-
+    protected open fun addComponents(circuit: ElectricalComponentSet) {
         connections.forEach { connection ->
             val offer = offerComponent(connection)
-            components.add(offer.component)
-        }
-
-        components.forEach { component ->
-            circuit.add(component)
+            circuit.add(offer.component)
         }
     }
 
@@ -238,12 +226,12 @@ abstract class ElectricalObject<C : Cell>(cell: C) : SimulationObject<C>(cell) {
      * Builds the connections, after the circuit was acquired in [setNewCircuit] and the components were added in [addComponents].
      * By default, offers for all [connections] are gathered using [offerComponent], and the components are connected using the pins indicated in the offers.
      * */
-    override fun build() {
+    open fun build(map: ElectricalConnectivityMap) {
         // Suggested by Grissess (and should have crossed my mind too, shame on me):
         connections.forEach { remote ->
             val localInfo = offerComponent(remote)
             val remoteInfo = remote.offerComponent(this)
-            localInfo.component.connect(localInfo.index, remoteInfo.component, remoteInfo.index)
+            map.connect(localInfo.component, localInfo.index, remoteInfo.component, remoteInfo.index)
         }
     }
 }

--- a/src/main/kotlin/org/eln2/mc/common/content/Grid.kt
+++ b/src/main/kotlin/org/eln2/mc/common/content/Grid.kt
@@ -765,16 +765,17 @@ class GridElectricalObject(cell: GridCell, val tapResistance: Double) : Electric
         externalResistor.clear()
     }
 
-    override fun build() {
+    override fun build(map: ElectricalConnectivityMap) {
         // Connects grids to grids, and external to external:
-        super.build()
+        super.build(map)
 
         if(externalResistor.isPresent) { // If not present, it is illegal to connect it (not in graph)
             // Connects grid to external:
             val offer = externalResistor.offerInternal()
 
             gridResistors.values.forEach { gridResistor ->
-                gridResistor.connect(
+                map.connect(
+                    gridResistor,
                     EXTERNAL_PIN,
                     offer.component,
                     offer.index
@@ -786,7 +787,7 @@ class GridElectricalObject(cell: GridCell, val tapResistance: Double) : Electric
             gridResistors.values.forEach { gridResistor1 ->
                 gridResistors.values.forEach { gridResistor2 ->
                     if(gridResistor1 != gridResistor2) {
-                        gridResistor1.connect(EXTERNAL_PIN, gridResistor2, EXTERNAL_PIN)
+                        map.connect(gridResistor1, EXTERNAL_PIN, gridResistor2, EXTERNAL_PIN)
                     }
                 }
             }

--- a/src/main/kotlin/org/eln2/mc/common/content/Ground.kt
+++ b/src/main/kotlin/org/eln2/mc/common/content/Ground.kt
@@ -2,6 +2,8 @@ package org.eln2.mc.common.content
 
 import mcp.mobius.waila.api.IPluginConfig
 import org.ageseries.libage.sim.electrical.mna.Circuit
+import org.eln2.mc.ElectricalComponentSet
+import org.eln2.mc.ElectricalConnectivityMap
 import org.eln2.mc.client.render.PartialModels
 import org.eln2.mc.client.render.foundation.BasicPartRenderer
 import org.eln2.mc.common.cells.foundation.*
@@ -13,7 +15,7 @@ import org.eln2.mc.integration.WailaTooltipBuilder
 import org.eln2.mc.mathematics.Base6Direction3dMask
 
 class GroundObject(cell: Cell) : ElectricalObject<Cell>(cell) {
-    private val resistors = ResistorBundle(0.01, this)
+    private val resistors = resistorBundle(0.01)
 
     val totalCurrent get() = resistors.totalCurrent
     val totalPower get() = resistors.totalPower
@@ -32,12 +34,12 @@ class GroundObject(cell: Cell) : ElectricalObject<Cell>(cell) {
         resistors.clear()
     }
 
-    override fun addComponents(circuit: Circuit) {
+    override fun addComponents(circuit: ElectricalComponentSet) {
         resistors.addComponents(connections, circuit)
     }
 
-    override fun build() {
-        resistors.connect(connections, this)
+    override fun build(map: ElectricalConnectivityMap) {
+        resistors.connect(connections, this, map)
         resistors.forEach { it.ground(INTERNAL_PIN) }
     }
 }

--- a/src/main/kotlin/org/eln2/mc/common/content/Ground.kt
+++ b/src/main/kotlin/org/eln2/mc/common/content/Ground.kt
@@ -33,7 +33,7 @@ class GroundObject(cell: Cell) : ElectricalObject<Cell>(cell) {
     }
 
     override fun addComponents(circuit: Circuit) {
-        resistors.register(connections, circuit)
+        resistors.addComponents(connections, circuit)
     }
 
     override fun build() {

--- a/src/main/kotlin/org/eln2/mc/common/content/VoltageSource.kt
+++ b/src/main/kotlin/org/eln2/mc/common/content/VoltageSource.kt
@@ -3,6 +3,8 @@ package org.eln2.mc.common.content
 import mcp.mobius.waila.api.IPluginConfig
 import org.ageseries.libage.sim.electrical.mna.Circuit
 import org.ageseries.libage.sim.electrical.mna.component.VoltageSource
+import org.eln2.mc.ElectricalComponentSet
+import org.eln2.mc.ElectricalConnectivityMap
 import org.eln2.mc.add
 import org.eln2.mc.client.render.PartialModels
 import org.eln2.mc.client.render.foundation.BasicPartRenderer
@@ -25,7 +27,7 @@ class VoltageSourceObject(cell: Cell) : ElectricalObject<Cell>(cell) {
         }
     }
 
-    private val resistors = ResistorBundle(0.01, this)
+    private val resistors = resistorBundle(0.01)
 
     /**
      * Gets or sets the potential of the voltage source.
@@ -57,15 +59,15 @@ class VoltageSourceObject(cell: Cell) : ElectricalObject<Cell>(cell) {
         resistors.clear()
     }
 
-    override fun addComponents(circuit: Circuit) {
+    override fun addComponents(circuit: ElectricalComponentSet) {
         circuit.add(source)
         resistors.addComponents(connections, circuit)
     }
 
-    override fun build() {
+    override fun build(map: ElectricalConnectivityMap) {
         source.ground(INTERNAL_PIN)
-        resistors.connect(connections, this)
-        resistors.forEach { it.connect(INTERNAL_PIN, source.instance, EXTERNAL_PIN) }
+        resistors.connect(connections, this, map)
+        resistors.forEach { map.connect(it, INTERNAL_PIN, source.instance, EXTERNAL_PIN) }
     }
 }
 

--- a/src/main/kotlin/org/eln2/mc/common/content/VoltageSource.kt
+++ b/src/main/kotlin/org/eln2/mc/common/content/VoltageSource.kt
@@ -59,7 +59,7 @@ class VoltageSourceObject(cell: Cell) : ElectricalObject<Cell>(cell) {
 
     override fun addComponents(circuit: Circuit) {
         circuit.add(source)
-        resistors.register(connections, circuit)
+        resistors.addComponents(connections, circuit)
     }
 
     override fun build() {

--- a/src/main/kotlin/org/eln2/mc/data/Histogram.kt
+++ b/src/main/kotlin/org/eln2/mc/data/Histogram.kt
@@ -1,5 +1,6 @@
 package org.eln2.mc.data
 
+// or multiset
 interface Histogram<K> {
     operator fun get(k: K): Int
     fun contains(k: K) = get(k) > 0
@@ -7,25 +8,28 @@ interface Histogram<K> {
 
 interface MutableHistogram<K> : Histogram<K> {
     operator fun set(k: K, n: Int)
-    fun add(k: K, n: Int = 1)
-    fun take(k: K, n: Int = 1)
-    operator fun plusAssign(k: K) = add(k)
-    operator fun minusAssign(k: K) = take(k)
+    fun add(k: K, n: Int = 1) : Int
+    fun take(k: K, n: Int = 1) : Int
+    operator fun plusAssign(k: K) { add(k) }
+    operator fun minusAssign(k: K) { take(k) }
     fun remove(k: K) = set(k, 0)
     fun clear()
 }
 
 class MutableMapHistogram<K>(val map: MutableMap<K, Int>) : MutableHistogram<K> {
+    constructor() : this(HashMap())
+
     override fun get(k: K) = map[k] ?: 0
-    override fun set(k: K, n: Int) {
-        map[k] = n
+
+    override fun set(k: K, n: Int) { map[k] = n }
+
+    override fun add(k: K, n: Int) : Int {
+        val result = get(k) + n
+        map[k] = result
+        return result
     }
 
-    override fun add(k: K, n: Int) {
-        map[k] = get(k) + n
-    }
-
-    override fun take(k: K, n: Int) {
+    override fun take(k: K, n: Int) : Int {
         val result = get(k) - n
 
         if (result < 0) {
@@ -33,6 +37,8 @@ class MutableMapHistogram<K>(val map: MutableMap<K, Int>) : MutableHistogram<K> 
         }
 
         this[k] = result
+
+        return result
     }
 
     override fun toString(): String {
@@ -49,6 +55,3 @@ class MutableMapHistogram<K>(val map: MutableMap<K, Int>) : MutableHistogram<K> 
 
     fun removeMapping(k: K) = map.remove(k)
 }
-
-fun <K> HashMapHistogram() = MutableMapHistogram<K>(HashMap())
-fun <K> LinkedHashMapHistogram() = MutableMapHistogram<K>(LinkedHashMap())

--- a/src/main/kotlin/org/eln2/mc/data/Lazy.kt
+++ b/src/main/kotlin/org/eln2/mc/data/Lazy.kt
@@ -1,0 +1,30 @@
+package org.eln2.mc.data
+
+interface LazyResettable<T> : Lazy<T> {
+    fun reset() : Boolean
+}
+
+class UnsafeLazyResettable<T>(private val new: () -> T) : LazyResettable<T> {
+    private var instance: T? = null
+
+    override fun reset(): Boolean {
+        val instance = this.instance
+        this.instance = null
+        return instance != null
+    }
+
+    override val value: T
+        get() {
+            val instance = this.instance
+
+            if(instance != null) {
+                return instance
+            }
+
+            val newValue = new()
+            this.instance = newValue
+            return newValue
+        }
+
+    override fun isInitialized() = instance != null
+}


### PR DESCRIPTION
Series resistors can be ❝merged❞ into a single equivalent resistor. This essentially *optimizes out* wires and grids by transforming linear segments of resistors into a single `Line` resistor.
The API can be used by replacing `Resistor` components with `ResistorVirtual` **Imaginary Components**. These components can be connected to other **Imaginary Components** and normal components. 
At the end of the building routine, real `Line` components are created for linear segments of virtual resistors.